### PR TITLE
The build image python:3.7-slim-stretch no longer has linux/s390x support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ##############################################################################
 FROM node:10.16.0-stretch-slim AS node
 
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim
 
 COPY --from=node /usr/local /usr/local
 


### PR DESCRIPTION
During build on the `linux/s390x` architecture one will see an output like this:
```
2020-08-03 00:27:35,224  root       INFO    run: 3.7-slim-stretch: Pulling from library/python
2020-08-03 00:27:35,228  root       INFO    run: no matching manifest for unknown in the manifest list entries
2020-08-03 00:27:35,230  root       INFO    run: return code = 1
2020-08-03 00:27:35,230  root       ERROR   exiting due to a non-zero return value: 1, cmd: docker build --disable-content-trust=true  -t docker.io/jinxiong/hpvs_bc_yorktown:latest -f ./Dockerfile ./
```

It turns out, `python:3.7-slim-stretch` no longer has `linux/s390x` architecture support:
```
# docker run --rm mplatform/mquery python:3.7-slim-stretch
Image: python:3.7-slim-stretch
 * Manifest List: Yes
 * Supported platforms:
   - linux/amd64
   - linux/arm/v5
   - linux/arm/v7
   - linux/arm64
   - linux/386
```

It looks like `python:3.7-slim` does have `linux/s390x` support:
```
# docker run --rm mplatform/mquery python:3.7-slim
Image: python:3.7-slim
 * Manifest List: Yes
 * Supported platforms:
   - linux/amd64
   - linux/arm/v5
   - linux/arm/v7
   - linux/arm64
   - linux/386
   - linux/mips64le
   - linux/ppc64le
   - linux/s390x
```

Tested building instead from `python:3.7-slim` b/c that still has `linux/s390x` support on s390, offers the same Python version and is also rather small in image size. The application successfully built. I then tested the wallet successfully. Functions tested: register, create and load single sig wallet, send and receive from testnet.