### PR TITLE
Add laravel/sanctum to composer.json

### DIFF
--- a/laravel-electrum/composer.json
+++ b/laravel-electrum/composer.json
@@ -9,6 +9,7 @@
         "araneadev/laravel-electrum": "dev-local",
         "laravel/framework": "^8.0",
         "laravel/tinker": "^2.0",
+        "laravel/sanctum": "^2.0",	    
         "fideloper/proxy": "^4.0",
         "fruitcake/laravel-cors": "^2.0.2"
     },


### PR DESCRIPTION
It appears that commit 226d1bfc3c774e24a79e68e9f1264b5ca359551f from August 11, 2021  within the laravel/laravel GitHub repo added the Sanctum library to Laravel:

https://github.com/laravel/laravel/commit/226d1bfc3c774e24a79e68e9f1264b5ca359551f

This broke the secure bitcoin sample application-  500 Internal Server error was received in the browser when doing pretty much anything.

A fix is to include the laravel/sanctum libary in the composer.json file.

I have tested this fix on both x86_64 and s390x architectures, and @chrispoole643 has also tested it on s390x architecture.