### PR TITLE
Specify Python 3.9.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ##############################################################################
 FROM node:16-buster-slim AS node
 
-FROM python:slim-buster
+FROM python:3.9.7-slim-buster
 
 COPY --from=node /usr/local /usr/local
 


### PR DESCRIPTION
The current image for python:slim-buster was created recently and uses Python 3.10.  The Electrum wallet is not working properly in Python 3.10 because it is evidently using a function or part of the language that had been deprecated and now finally removed in Python 3.10.  To see the error messages, build the secure bitcoin wallet image and run it and look in /tmp/electrum-daemon.err within the container.  You can build the image and create a wallet, and even use your key to receive bitcoin from the testnet, but the problem is that the wallet never synchronizes its history and you can never see your transactions within the Electrum application.   By changing from using python:slim-buster to python:3.9.7-slim-buster in Dockerfile, you are building the image on Python 3.9.7, and the expected application functionality works again.